### PR TITLE
Improve arrows to make them look more uniform. 

### DIFF
--- a/templates/app.html
+++ b/templates/app.html
@@ -20,7 +20,7 @@
         <div class="version-label">{{ package["version"] | truncate(15) }}</div>
         <div class="release-date-title">Release Date:</div>
         <div class="release-date-label">{{ package["release_date"] | truncate(45) }}</div>
-        <p><a href="./apps" class="link_button" style="float: left;"><- Back to All Apps</a><a href="#" class="link_button" style="float: right;">Download App</a></p>
+        <p><a href="./apps" class="link_button" style="float: left;">&#8592; Back to All Apps</a><a href="#" class="link_button" style="float: right;">Download App</a></p>
     </div>
 
 </section>

--- a/templates/error.html
+++ b/templates/error.html
@@ -12,7 +12,7 @@
         <img src="{{ url_for('static', filename='error_view.png') }}" style="width:100%;">
         <div class="title-label">Open Shop Channel has encountered an error!</div>
         <div class="error-description">{{ description }}</div>
-        <p><a href="./home" class="link_button_error" style="float: left;"><- Back Home</a></p>
+        <p><a href="./home" class="link_button_error" style="float: left;">&#8592; Back Home</a></p>
     </div>
 
 </section>

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,6 +14,6 @@
         <div class="featured-title">Featured App</div>
         <div class="news-title">News</div>
         <div class="all-apps-button"><a href="./apps" class="link_button_small">All Apps</a></div>
-        <p><a href="#" class="link_button" style="float: left;"><- Exit to Wii Menu</a></p>
+        <p><a href="#" class="link_button" style="float: left;">&#8592; Exit to Wii Menu</a></p>
     </div>
 </section>


### PR DESCRIPTION
I changed the arrows from <- to ←, which should make it look more uniform. 

Unfortunately, since I can't the WSC working with a custom BIND DNS (it just errors out) I cannot fully test this, but I can confirm that it does work on a later version of Chrome, and I'd be surprised if it wasn't supported by the Wii. 

The code I used is `&#8592;`.

# Screenshots

![image](https://user-images.githubusercontent.com/52163910/110218690-17cf1a00-7e89-11eb-8e1a-ad0515cc8d3d.png)

![image](https://user-images.githubusercontent.com/52163910/110218704-24537280-7e89-11eb-99c9-ec4adfee14dc.png)

![image](https://user-images.githubusercontent.com/52163910/110218719-39c89c80-7e89-11eb-86fe-0f7d1f772f98.png)