### PR TITLE
Switch to request.json() in osc.py

### DIFF
--- a/osc.py
+++ b/osc.py
@@ -1,4 +1,3 @@
-import json
 from datetime import datetime
 from functools import reduce
 
@@ -36,7 +35,7 @@ class API:
     packages = None
 
     def load_packages(self):
-        self.packages = json.loads(requests.get(config.api_endpoint).text)
+        self.packages = requests.get(config.api_endpoint).json()
 
     def get_packages(self):
         return self.packages


### PR DESCRIPTION
This uses the Response .json() method.

Hope this helps. Not sure if this was already considered. It was a simple change, so I felt it would be faster and easier to submit a potentially rejected two-line PR than to file an issue first; I hope that's OK.